### PR TITLE
renaming cluster role binding to avoid collisions

### DIFF
--- a/pkg/sentry/authz/authz.go
+++ b/pkg/sentry/authz/authz.go
@@ -202,7 +202,7 @@ func setRoleValues(r *rbacv1.Role, nsName, permission string) {
 }
 
 func getClusterRoleBindingName(saName, clusterRole string) string {
-	return clusterRole + "-" + saName + "-cr-binding"
+	return clusterRole + "-ps-" + saName + "-cr-binding"
 }
 
 func getClusterRoleBinding(sa *corev1.ServiceAccount, clusterRole string) *rbacv1.ClusterRoleBinding {


### PR DESCRIPTION
### What does this PR change?

- changed cluster role binding resource name to avoid collision with other resources

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
