### PR TITLE
Update Arch. with arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## Fixed
+
+- Fixed issue where relay server is not coming up in arm64 (Mac M1) [sandeep540](https://github.com/sandeep540)
+
 ## [0.1.3] - 2022-08-26
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## Fixed
 
-- Fixed issue where relay server is not coming up in arm64 (Mac M1) [sandeep540](https://github.com/sandeep540)
+- Fixed issue where relay server is not coming up in arm64 (Mac M1) from [sandeep540](https://github.com/sandeep540)
 
 ## [0.1.3] - 2022-08-26
 

--- a/internal/cluster/fixtures/data/download.yaml
+++ b/internal/cluster/fixtures/data/download.yaml
@@ -318,6 +318,7 @@ spec:
                     operator: In
                     values:
                       - amd64
+                      - arm64
       terminationGracePeriodSeconds: 10
       priorityClassName: paralus-cluster-critical
       serviceAccountName: system-sa


### PR DESCRIPTION
For nodeAffinity, additional arch. Option arm64 is added

### What does this PR change?

- It will enable the Paralus to run as Server or Client on Apple Mac M1 (arm64) and relay server will come up without any issue

### Does the PR depend on any other PRs or Issues? If yes, please list them.

-

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`

For issue #70 
