### PR TITLE
changes to cluster lister, group creation date and default relay version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## Fixed
 
 - Fixed issue where relay server is not coming up in arm64 (Mac M1) from [sandeep540](https://github.com/sandeep540)
+- Fixed cluster lister and set group created at property [niravparikh05](https://github.com/niravparikh05)
 
 ## [0.1.3] - 2022-08-26
 

--- a/internal/cluster/dao/cluster.go
+++ b/internal/cluster/dao/cluster.go
@@ -103,6 +103,14 @@ func ListClusters(ctx context.Context, db bun.IDB, qo commonv3.QueryOptions) (cl
 	oid := uuid.NullUUID{UUID: uuid.MustParse(qo.Organization), Valid: true}
 	prid := uuid.NullUUID{UUID: uuid.MustParse(qo.Project), Valid: true}
 
+	if qo.Q != "" || qo.OrderBy != "" {
+		_, err = dao.ListFiltered(ctx, db, pid, oid, prid, &clusters, qo.Q, qo.OrderBy, qo.Order, int(qo.Limit), int(qo.Offset))
+		if err != nil {
+			return nil, err
+		}
+		return clusters, err
+	}
+
 	err = dao.ListByProject(ctx, db, pid, oid, prid, &clusters)
 	if err != nil {
 		return nil, err

--- a/internal/dao/common.go
+++ b/internal/dao/common.go
@@ -236,7 +236,7 @@ func List(ctx context.Context, db bun.IDB, partnerId uuid.NullUUID, organization
 // TODO: Should we simplify this (less args)?
 func ListFiltered(ctx context.Context, db bun.IDB,
 	partnerId uuid.NullUUID, organizationId uuid.NullUUID,
-	entities interface{},
+	projectId uuid.NullUUID, entities interface{},
 	query string, orderBy string, order string,
 	limit int, offset int) (interface{}, error) {
 	sq := db.NewSelect().Model(entities)
@@ -248,6 +248,9 @@ func ListFiltered(ctx context.Context, db bun.IDB,
 	}
 	if organizationId.Valid {
 		sq = sq.Where("organization_id = ?", organizationId)
+	}
+	if projectId.Valid {
+		sq = sq.Where("project_id = ?", projectId)
 	}
 	sq = sq.Where("trash = ?", false)
 	if orderBy != "" && order != "" {

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func setup() {
 	viper.SetDefault(coreRelayUserHostEnv, "*.user.relay.paralus.local:10002")
 	viper.SetDefault(sentryBootstrapEnv, "console.paralus.dev:443")
 	viper.SetDefault(bootstrapKEKEnv, "paralus")
-	viper.SetDefault(relayImageEnv, "paralusio/relay:v1.0.0-beta")
+	viper.SetDefault(relayImageEnv, "paralusio/relay:v0.1.0")
 
 	// audit
 	viper.SetDefault(esEndPointEnv, "http://127.0.0.1:9200")

--- a/pkg/service/cluster.go
+++ b/pkg/service/cluster.go
@@ -416,6 +416,7 @@ func (s *clusterService) prepareClusterResponse(ctx context.Context, clstr *infr
 		Organization: org.Name,
 		Partner:      part.Name,
 		ModifiedAt:   timestamppb.New(c.ModifiedAt),
+		CreatedAt:    timestamppb.New(c.CreatedAt),
 	}
 
 	sm := int32(infrav3.ClusterShareMode_ClusterShareModeNotSet)
@@ -681,6 +682,11 @@ func (cs *clusterService) List(ctx context.Context, opts ...query.Option) (*infr
 		Project:      proj.ID.String(),
 		Organization: proj.OrganizationId.String(),
 		Partner:      proj.PartnerId.String(),
+		Q:            queryOptions.Q,
+		OrderBy:      queryOptions.OrderBy,
+		Order:        queryOptions.Order,
+		Limit:        queryOptions.Limit,
+		Offset:       queryOptions.Offset,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/service/group.go
+++ b/pkg/service/group.go
@@ -412,6 +412,7 @@ func (s *groupService) toV3Group(ctx context.Context, db bun.IDB, group *userv3.
 		Partner:      group.GetMetadata().GetPartner(),
 		Labels:       labels,
 		ModifiedAt:   timestamppb.New(grp.ModifiedAt),
+		CreatedAt:    timestamppb.New(grp.CreatedAt),
 	}
 	users, err := dao.GetUsers(ctx, db, grp.ID)
 	if err != nil {
@@ -613,6 +614,7 @@ func (s *groupService) List(ctx context.Context, opts ...query.Option) (*userv3.
 	var grps []models.Group
 	entities, err := dao.ListFiltered(ctx, s.db,
 		uuid.NullUUID{UUID: partId, Valid: true}, uuid.NullUUID{UUID: orgId, Valid: true},
+		uuid.NullUUID{Valid: false},
 		&grps,
 		queryOptions.Q,
 		queryOptions.OrderBy,


### PR DESCRIPTION
### What does this PR change?

- Fixes https://github.com/paralus/dashboard/issues/115 and sets group created at property

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
