### PR TITLE
Fix: validate non empty projects for delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## Fixed
+- Able to Deleted Project With Clusters In It from [mabhi](https://github.com/mabhi)
 ## [0.2.0] - 2023-01-27
 
 ## Fixed

--- a/pkg/reconcile/cluster_handler.go
+++ b/pkg/reconcile/cluster_handler.go
@@ -148,7 +148,7 @@ func (h *clusterEventHandler) handleClusterEvent(ev event.Resource) {
 
 	if ev.ID != "" {
 		cluster, err = h.cs.Select(ctx, &infrav3.Cluster{
-			Metadata: &commonv3.Metadata{Id: ev.ID},
+			Metadata: &commonv3.Metadata{Id: ev.ID, Project: ev.ProjectID},
 		}, true)
 	} else {
 
@@ -156,6 +156,7 @@ func (h *clusterEventHandler) handleClusterEvent(ev event.Resource) {
 			query.WithName(ev.Name),
 			query.WithPartnerID(ev.PartnerID),
 			query.WithOrganizationID(ev.OrganizationID),
+			query.WithProjectID(ev.ProjectID),
 		)
 	}
 
@@ -196,7 +197,7 @@ func (h *clusterEventHandler) handleClusterWorkloadEvent(ev event.Resource) {
 
 	if ev.ID != "" {
 		cluster, err = h.cs.Select(ctx, &infrav3.Cluster{
-			Metadata: &commonv3.Metadata{Id: ev.ID},
+			Metadata: &commonv3.Metadata{Id: ev.ID, Project: ev.ProjectID},
 		}, true)
 	} else {
 		cluster, err = h.cs.Get(ctx,

--- a/pkg/service/bootstrap.go
+++ b/pkg/service/bootstrap.go
@@ -188,6 +188,7 @@ func prepareAgentResponse(agent *models.BootstrapAgent) *sentry.BootstrapAgent {
 			ModifiedAt:  timestamppb.New(agent.ModifiedAt),
 			Labels:      lbls,
 			Annotations: ann,
+			Project:     agent.ProjectId.String(),
 		},
 		Spec: &sentry.BootstrapAgentSpec{
 			Token:       agent.Token,

--- a/pkg/service/cluster_test.go
+++ b/pkg/service/cluster_test.go
@@ -79,6 +79,8 @@ func TestUpdateCluster(t *testing.T) {
 	puuid := uuid.New().String()
 	cuuid := uuid.New().String()
 
+	mock.ExpectQuery(`SELECT "project"."id"`).WithArgs().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(puuid))
+
 	mock.ExpectQuery(`SELECT "cluster"."id", "cluster"."organization_id"`).
 		WithArgs().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(cuuid))
 
@@ -113,6 +115,8 @@ func TestSelectCluster(t *testing.T) {
 	puuid := uuid.New().String()
 	cuuid := uuid.New().String()
 
+	mock.ExpectQuery(`SELECT "project"."id"`).WithArgs().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(puuid))
+
 	mock.ExpectQuery(`SELECT "cluster"."id", "cluster"."organization_id"`).
 		WithArgs().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(cuuid))
 
@@ -146,6 +150,8 @@ func TestGetCluster(t *testing.T) {
 
 	puuid := uuid.New().String()
 	cuuid := uuid.New().String()
+
+	// mock.ExpectQuery(`SELECT "project"."id"`).WithArgs().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(puuid))
 
 	mock.ExpectQuery(`SELECT "cluster"."id", "cluster"."organization_id"`).
 		WithArgs().WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(cuuid))

--- a/server/bootstrap.go
+++ b/server/bootstrap.go
@@ -249,16 +249,17 @@ func (s *bootstrapServer) RegisterBootstrapAgent(ctx context.Context, in *sentry
 
 	if template.Metadata.Name == "paralus-core-relay-agent" {
 		_log.Info("updating cluster status for :: ", agent.Metadata.Name)
-		err = s.updateClusterStatus(ctx, agent.Metadata.Name)
+		err = s.updateClusterStatus(ctx, agent.Metadata.Name, agent.Metadata.Project)
 	}
 
 	return
 }
 
-func (s *bootstrapServer) updateClusterStatus(ctx context.Context, clusterID string) error {
+func (s *bootstrapServer) updateClusterStatus(ctx context.Context, clusterID, projectID string) error {
 	cluster := &infrav3.Cluster{
 		Metadata: &commonv3.Metadata{
-			Id: clusterID,
+			Id:      clusterID,
+			Project: projectID,
 		},
 		Spec: &infrav3.ClusterSpec{
 			ClusterData: &infrav3.ClusterData{


### PR DESCRIPTION
Signed-off-by: mabhi <abhijit.mukherjee@infracloud.io>

### What does this PR change?

- Resolves issue [141](https://github.com/paralus/paralus/issues/141)
- Validate delete project requests for presence of clusters inside the target project

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [x] Added tests for this PR
- [ ] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
