### PR TITLE
Add needs-triage label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Report a bug or unexpected behavior
 title: ""
-labels: "new, bug"
+labels: "bug, needs-triage"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Request a new feature or improvement
 title: ""
-labels: "new, enhancement, feature"
+labels: "enhancement, feature, needs-triage"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -2,7 +2,7 @@
 name: Other
 about: Something else
 title: ""
-labels: "new"
+labels: "needs-triage"
 assignees: ""
 ---
 


### PR DESCRIPTION
### What does this PR change?
Automatically sets `needs-triage` label to all issues created using issue templates.

### Does the PR depend on any other PRs or Issues? If yes, please list them.
No

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [X] Added tests for this PR
- [X] Formatted the code using `go fmt` (if applicable)
- [X] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [X] Updated `CHANGELOG.md`
