### PR TITLE
Fix re-running admindb migration failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.7'
 
 services:
   postgresd:
-    image: postgres:13.4
-    container_name: paralus_postgres_13
+    image: postgres:14.2
+    container_name: paralus_postgres_14
     ports:
       - "$DB_PORT:$DB_PORT"
     volumes:
@@ -60,4 +60,3 @@ services:
 
 volumes:
   paralus_db_data:
-  paralus_es_data:

--- a/persistence/migrations/admindb/000001_authsrv_partner.up.sql
+++ b/persistence/migrations/admindb/000001_authsrv_partner.up.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE IF NOT EXISTS authsrv_partner (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -22,12 +22,10 @@ CREATE TABLE IF NOT EXISTS authsrv_partner (
     is_synthetic_partner_enabled boolean NOT NULL
 );
 
-ALTER TABLE ONLY authsrv_partner ADD CONSTRAINT authsrv_partner_pkey PRIMARY KEY (id);
+CREATE UNIQUE INDEX IF NOT EXISTS authsrv_partner_unique_name ON authsrv_partner (name) WHERE trash IS false;
 
-CREATE UNIQUE index authsrv_partner_unique_name ON authsrv_partner (name) WHERE trash IS false;
+CREATE INDEX IF NOT EXISTS authsrv_partner_name_b6a8d21f ON authsrv_partner USING btree (name);
 
-CREATE INDEX authsrv_partner_name_b6a8d21f ON authsrv_partner USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_partner_name_b6a8d21f_like ON authsrv_partner USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_partner_name_b6a8d21f_like ON authsrv_partner USING btree (name varchar_pattern_ops);
-
-CREATE INDEX authsrv_partner_parent_id_5e0680af ON authsrv_partner USING btree (parent_id);
+CREATE INDEX IF NOT EXISTS authsrv_partner_parent_id_5e0680af ON authsrv_partner USING btree (parent_id);

--- a/persistence/migrations/admindb/000002_authsrv_organization.up.sql
+++ b/persistence/migrations/admindb/000002_authsrv_organization.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_organization (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS authsrv_organization (
     trash boolean NOT NULL,
     settings jsonb NOT NULL,
     billing_address text NOT NULL,
-    partner_id uuid NOT NULL,
+    partner_id uuid NOT NULL REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
     active boolean NOT NULL,
     approved boolean NOT NULL,
     type character varying(64) NOT NULL,
@@ -25,20 +25,12 @@ CREATE TABLE IF NOT EXISTS authsrv_organization (
     psps_enabled boolean default TRUE,
     custom_psps_enabled boolean,
     default_blueprints_enabled boolean default TRUE,
-    referer character varying(30)
+    referer character varying(30),
+    CONSTRAINT authsrv_organization_name_partner_id_7d1113b9_uniq UNIQUE (name, partner_id)
 );
 
-ALTER TABLE ONLY authsrv_organization
-    ADD CONSTRAINT authsrv_organization_name_partner_id_7d1113b9_uniq UNIQUE (name, partner_id);
+CREATE INDEX IF NOT EXISTS authsrv_organization_name_23376e56 ON authsrv_organization USING btree (name);
 
-ALTER TABLE ONLY authsrv_organization ADD CONSTRAINT authsrv_organization_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_organization_name_23376e56_like ON authsrv_organization USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_organization_name_23376e56 ON authsrv_organization USING btree (name);
-
-CREATE INDEX authsrv_organization_name_23376e56_like ON authsrv_organization USING btree (name varchar_pattern_ops);
-
-CREATE INDEX authsrv_organization_partner_id_7b55b579 ON authsrv_organization USING btree (partner_id);
-
-ALTER TABLE ONLY authsrv_organization
-    ADD CONSTRAINT authsrv_organization_partner_id_7b55b579_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_organization_partner_id_7b55b579 ON authsrv_organization USING btree (partner_id);

--- a/persistence/migrations/admindb/000003_authsrv_project.up.sql
+++ b/persistence/migrations/admindb/000003_authsrv_project.up.sql
@@ -1,32 +1,22 @@
 CREATE TABLE IF NOT EXISTS authsrv_project (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
     trash boolean NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
     "default" boolean NOT NULL
 );
 
-ALTER TABLE ONLY authsrv_project ADD CONSTRAINT authsrv_project_pkey PRIMARY KEY (id);
-
 -- update when we have more than one org
-CREATE UNIQUE index authsrv_project_unique_name ON authsrv_project (name) WHERE trash IS false;
+CREATE UNIQUE INDEX IF NOT EXISTS authsrv_project_unique_name ON authsrv_project (name) WHERE trash IS false;
 
-CREATE INDEX authsrv_project_name_1b8dd279 ON authsrv_project USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_project_name_1b8dd279 ON authsrv_project USING btree (name);
 
-CREATE INDEX authsrv_project_name_1b8dd279_like ON authsrv_project USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_project_name_1b8dd279_like ON authsrv_project USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_project_organization_id_77437387 ON authsrv_project USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_project_organization_id_77437387 ON authsrv_project USING btree (organization_id);
 
-CREATE INDEX authsrv_project_partner_id_3d505b76 ON authsrv_project USING btree (partner_id);
-
-ALTER TABLE ONLY authsrv_project
-    ADD CONSTRAINT authsrv_project_organization_id_77437387_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_project
-    ADD CONSTRAINT authsrv_project_partner_id_3d505b76_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_project_partner_id_3d505b76 ON authsrv_project USING btree (partner_id);

--- a/persistence/migrations/admindb/000004_authsrv_account.up.sql
+++ b/persistence/migrations/admindb/000004_authsrv_account.up.sql
@@ -1,14 +1,14 @@
 CREATE TABLE IF NOT EXISTS authsrv_ssoaccount (
     password character varying(128) NOT NULL,
     last_login timestamp with time zone,
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
-    organization_id uuid,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
     trash boolean NOT NULL,
-    username character varying(256) NOT NULL,
+    username character varying(256) NOT NULL UNIQUE,
     phone character varying(36) NOT NULL,
     first_name character varying(64) NOT NULL,
     last_name character varying(64) NOT NULL,
@@ -16,18 +16,10 @@ CREATE TABLE IF NOT EXISTS authsrv_ssoaccount (
     last_logout timestamp with time zone
 );
 
-ALTER TABLE ONLY authsrv_ssoaccount ADD CONSTRAINT authsrv_ssoaccount_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_ssoaccount_name_4def83cc ON authsrv_ssoaccount USING btree (name);
 
-ALTER TABLE ONLY authsrv_ssoaccount ADD CONSTRAINT authsrv_ssoaccount_username_key UNIQUE (username);
+CREATE INDEX IF NOT EXISTS authsrv_ssoaccount_name_4def83cc_like ON authsrv_ssoaccount USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_ssoaccount_name_4def83cc ON authsrv_ssoaccount USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_ssoaccount_organization_id_d2a979a5 ON authsrv_ssoaccount USING btree (organization_id);
 
-CREATE INDEX authsrv_ssoaccount_name_4def83cc_like ON authsrv_ssoaccount USING btree (name varchar_pattern_ops);
-
-CREATE INDEX authsrv_ssoaccount_organization_id_d2a979a5 ON authsrv_ssoaccount USING btree (organization_id);
-
-CREATE INDEX authsrv_ssoaccount_username_029374ce_like ON authsrv_ssoaccount USING btree (username varchar_pattern_ops);
-
-ALTER TABLE ONLY authsrv_ssoaccount
-    ADD CONSTRAINT authsrv_ssoaccount_organization_id_d2a979a5_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_ssoaccount_username_029374ce_like ON authsrv_ssoaccount USING btree (username varchar_pattern_ops);

--- a/persistence/migrations/admindb/000005_authsrv_group.up.sql
+++ b/persistence/migrations/admindb/000005_authsrv_group.up.sql
@@ -1,29 +1,19 @@
 CREATE TABLE IF NOT EXISTS authsrv_group (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
     trash boolean NOT NULL,
-    organization_id uuid NOT NULL,
-    partner_id uuid NOT NULL,
+    organization_id uuid NOT NULL REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid NOT NULL REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
     type character varying(64) NOT NULL
 );
 
-ALTER TABLE ONLY authsrv_group ADD CONSTRAINT authsrv_group_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_group_name_d90b4524 ON authsrv_group USING btree (name);
 
-CREATE INDEX authsrv_group_name_d90b4524 ON authsrv_group USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_group_name_d90b4524_like ON authsrv_group USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_group_name_d90b4524_like ON authsrv_group USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_group_organization_id_e070e826 ON authsrv_group USING btree (organization_id);
 
-CREATE INDEX authsrv_group_organization_id_e070e826 ON authsrv_group USING btree (organization_id);
-
-CREATE INDEX authsrv_group_partner_id_1de9ab46 ON authsrv_group USING btree (partner_id);
-
-ALTER TABLE ONLY authsrv_group
-    ADD CONSTRAINT authsrv_group_organization_id_e070e826_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_group
-    ADD CONSTRAINT authsrv_group_partner_id_1de9ab46_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_group_partner_id_1de9ab46 ON authsrv_group USING btree (partner_id);

--- a/persistence/migrations/admindb/000007_authsrv_resourcerole.up.sql
+++ b/persistence/migrations/admindb/000007_authsrv_resourcerole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_resourcerole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -8,24 +8,14 @@ CREATE TABLE IF NOT EXISTS authsrv_resourcerole (
     is_global boolean NOT NULL,
     builtin boolean NOT NULL,
     scope character varying(256) NOT NULL,
-    organization_id uuid,
-    partner_id uuid
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_resourcerole ADD CONSTRAINT authsrv_resourcerole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_resourcerole_name_a93b875a ON authsrv_resourcerole USING btree (name);
 
-CREATE INDEX authsrv_resourcerole_name_a93b875a ON authsrv_resourcerole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_resourcerole_name_a93b875a_like ON authsrv_resourcerole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_resourcerole_name_a93b875a_like ON authsrv_resourcerole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_resourcerole_organization_id_9a0a7e7e ON authsrv_resourcerole USING btree (organization_id);
 
-CREATE INDEX authsrv_resourcerole_organization_id_9a0a7e7e ON authsrv_resourcerole USING btree (organization_id);
-
-CREATE INDEX authsrv_resourcerole_partner_id_de49ca91 ON authsrv_resourcerole USING btree (partner_id);
-
-ALTER TABLE ONLY authsrv_resourcerole
-    ADD CONSTRAINT authsrv_resourcerole_organization_id_9a0a7e7e_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_resourcerole
-    ADD CONSTRAINT authsrv_resourcerole_partner_id_de49ca91_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_resourcerole_partner_id_de49ca91 ON authsrv_resourcerole USING btree (partner_id);

--- a/persistence/migrations/admindb/000008_authsrv_resourcepermission.up.sql
+++ b/persistence/migrations/admindb/000008_authsrv_resourcepermission.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_resourcepermission (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     scope character varying(256) NOT NULL,
     base_url character varying(256) NOT NULL,
@@ -11,8 +11,6 @@ CREATE TABLE IF NOT EXISTS authsrv_resourcepermission (
     resource_action_urls jsonb NOT NULL
 );
 
-ALTER TABLE ONLY authsrv_resourcepermission ADD CONSTRAINT authsrv_resourcepermission_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_resourcepermission_name_97f09d50 ON authsrv_resourcepermission USING btree (name);
 
-CREATE INDEX authsrv_resourcepermission_name_97f09d50 ON authsrv_resourcepermission USING btree (name);
-
-CREATE INDEX authsrv_resourcepermission_name_97f09d50_like ON authsrv_resourcepermission USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_resourcepermission_name_97f09d50_like ON authsrv_resourcepermission USING btree (name varchar_pattern_ops);

--- a/persistence/migrations/admindb/000009_authsrv_resourcerolepermission.up.sql
+++ b/persistence/migrations/admindb/000009_authsrv_resourcerolepermission.up.sql
@@ -1,24 +1,18 @@
 CREATE TABLE IF NOT EXISTS authsrv_resourcerolepermission (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
     trash boolean NOT NULL,
-    resource_permission_id uuid NOT NULL,
+    resource_permission_id uuid NOT NULL REFERENCES authsrv_resourcepermission(id) DEFERRABLE INITIALLY DEFERRED,
     resource_role_id uuid NOT NULL
 );
 
-ALTER TABLE ONLY authsrv_resourcerolepermission ADD CONSTRAINT authsrv_resourcerolepermission_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_resourcerolepermission_name_a65794e7 ON authsrv_resourcerolepermission USING btree (name);
 
-CREATE INDEX authsrv_resourcerolepermission_name_a65794e7 ON authsrv_resourcerolepermission USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_resourcerolepermission_name_a65794e7_like ON authsrv_resourcerolepermission USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_resourcerolepermission_name_a65794e7_like ON authsrv_resourcerolepermission USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_resourcerolepermission_resource_permission_id_c076e909 ON authsrv_resourcerolepermission USING btree (resource_permission_id);
 
-CREATE INDEX authsrv_resourcerolepermission_resource_permission_id_c076e909 ON authsrv_resourcerolepermission USING btree (resource_permission_id);
-
-CREATE INDEX authsrv_resourcerolepermission_resource_role_id_054f52d8 ON authsrv_resourcerolepermission USING btree (resource_role_id);
-
-ALTER TABLE ONLY authsrv_resourcerolepermission
-    ADD CONSTRAINT authsrv_resourcerole_resource_permission__c076e909_fk_authsrv_r FOREIGN KEY (resource_permission_id) 
-    REFERENCES authsrv_resourcepermission(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_resourcerolepermission_resource_role_id_054f52d8 ON authsrv_resourcerolepermission USING btree (resource_role_id);

--- a/persistence/migrations/admindb/000010_authsrv_projectaccountresourcerole.up.sql
+++ b/persistence/migrations/admindb/000010_authsrv_projectaccountresourcerole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_projectaccountresourcerole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -8,40 +8,22 @@ CREATE TABLE IF NOT EXISTS authsrv_projectaccountresourcerole (
     "default" boolean NOT NULL,
     active boolean NOT NULL,
     account_id uuid NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
-    project_id uuid,
-    role_id uuid NOT NULL
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
+    project_id uuid REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED,
+    role_id uuid NOT NULL REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_projectaccountresourcerole ADD CONSTRAINT authsrv_projectaccountresourcerole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_account_id_532ce8df ON authsrv_projectaccountresourcerole USING btree (account_id);
 
-CREATE INDEX authsrv_projectaccountresourcerole_account_id_532ce8df ON authsrv_projectaccountresourcerole USING btree (account_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_name_c4c3d60f ON authsrv_projectaccountresourcerole USING btree (name);
 
-CREATE INDEX authsrv_projectaccountresourcerole_name_c4c3d60f ON authsrv_projectaccountresourcerole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_name_c4c3d60f_like ON authsrv_projectaccountresourcerole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_projectaccountresourcerole_name_c4c3d60f_like ON authsrv_projectaccountresourcerole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_organization_id_91c5602d ON authsrv_projectaccountresourcerole USING btree (organization_id);
 
-CREATE INDEX authsrv_projectaccountresourcerole_organization_id_91c5602d ON authsrv_projectaccountresourcerole USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_partner_id_81bde92c ON authsrv_projectaccountresourcerole USING btree (partner_id);
 
-CREATE INDEX authsrv_projectaccountresourcerole_partner_id_81bde92c ON authsrv_projectaccountresourcerole USING btree (partner_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_project_id_f8a43852 ON authsrv_projectaccountresourcerole USING btree (project_id);
 
-CREATE INDEX authsrv_projectaccountresourcerole_project_id_f8a43852 ON authsrv_projectaccountresourcerole USING btree (project_id);
-
-CREATE INDEX authsrv_projectaccountresourcerole_role_id_a345b16f ON authsrv_projectaccountresourcerole USING btree (role_id);
-
-ALTER TABLE ONLY authsrv_projectaccountresourcerole
-    ADD CONSTRAINT authsrv_projectaccou_organization_id_91c5602d_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectaccountresourcerole
-    ADD CONSTRAINT authsrv_projectaccou_partner_id_81bde92c_fk_authsrv_p FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectaccountresourcerole
-    ADD CONSTRAINT authsrv_projectaccou_project_id_f8a43852_fk_authsrv_p FOREIGN KEY (project_id) 
-    REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectaccountresourcerole
-    ADD CONSTRAINT authsrv_projectaccou_role_id_a345b16f_fk_authsrv_r FOREIGN KEY (role_id) 
-    REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountresourcerole_role_id_a345b16f ON authsrv_projectaccountresourcerole USING btree (role_id);

--- a/persistence/migrations/admindb/000011_authsrv_projectaccountnamespacerole.up.sql
+++ b/persistence/migrations/admindb/000011_authsrv_projectaccountnamespacerole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_projectaccountnamespacerole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -8,40 +8,22 @@ CREATE TABLE IF NOT EXISTS authsrv_projectaccountnamespacerole (
     namespace character varying(64) NOT NULL,
     active boolean NOT NULL,
     account_id uuid NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
-    project_id uuid,
-    role_id uuid NOT NULL
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
+    project_id uuid REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED,
+    role_id uuid NOT NULL REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_projectaccountnamespacerole ADD CONSTRAINT authsrv_projectaccountnamespacerole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_account_id_4fac0ac2 ON authsrv_projectaccountnamespacerole USING btree (account_id);
 
-CREATE INDEX authsrv_projectaccountnamespacerole_account_id_4fac0ac2 ON authsrv_projectaccountnamespacerole USING btree (account_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_name_216353a4 ON authsrv_projectaccountnamespacerole USING btree (name);
 
-CREATE INDEX authsrv_projectaccountnamespacerole_name_216353a4 ON authsrv_projectaccountnamespacerole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_name_216353a4_like ON authsrv_projectaccountnamespacerole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_projectaccountnamespacerole_name_216353a4_like ON authsrv_projectaccountnamespacerole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_organization_id_96c921c9 ON authsrv_projectaccountnamespacerole USING btree (organization_id);
 
-CREATE INDEX authsrv_projectaccountnamespacerole_organization_id_96c921c9 ON authsrv_projectaccountnamespacerole USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_partner_id_9bec6899 ON authsrv_projectaccountnamespacerole USING btree (partner_id);
 
-CREATE INDEX authsrv_projectaccountnamespacerole_partner_id_9bec6899 ON authsrv_projectaccountnamespacerole USING btree (partner_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_project_id_66e567ed ON authsrv_projectaccountnamespacerole USING btree (project_id);
 
-CREATE INDEX authsrv_projectaccountnamespacerole_project_id_66e567ed ON authsrv_projectaccountnamespacerole USING btree (project_id);
-
-CREATE INDEX authsrv_projectaccountnamespacerole_role_id_8a5411cc ON authsrv_projectaccountnamespacerole USING btree (role_id);
-
-ALTER TABLE ONLY authsrv_projectaccountnamespacerole
-    ADD CONSTRAINT authsrv_projectaccou_organization_id_96c921c9_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectaccountnamespacerole
-    ADD CONSTRAINT authsrv_projectaccou_partner_id_9bec6899_fk_authsrv_p FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectaccountnamespacerole
-    ADD CONSTRAINT authsrv_projectaccou_project_id_66e567ed_fk_authsrv_p FOREIGN KEY (project_id) 
-    REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectaccountnamespacerole
-    ADD CONSTRAINT authsrv_projectaccou_role_id_8a5411cc_fk_authsrv_r FOREIGN KEY (role_id) 
-    REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_projectaccountnamespacerole_role_id_8a5411cc ON authsrv_projectaccountnamespacerole USING btree (role_id);

--- a/persistence/migrations/admindb/000012_authsrv_projectgroupnamespacerole.up.sql
+++ b/persistence/migrations/admindb/000012_authsrv_projectgroupnamespacerole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_projectgroupnamespacerole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -7,45 +7,23 @@ CREATE TABLE IF NOT EXISTS authsrv_projectgroupnamespacerole (
     trash boolean NOT NULL,
     namespace character varying(64) NOT NULL,
     active boolean NOT NULL,
-    group_id uuid NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
-    project_id uuid,
-    role_id uuid NOT NULL
+    group_id uuid NOT NULL REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
+    project_id uuid REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED,
+    role_id uuid NOT NULL REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_projectgroupnamespacerole ADD CONSTRAINT authsrv_projectgroupnamespacerole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_group_id_15ba5c48 ON authsrv_projectgroupnamespacerole USING btree (group_id);
 
-CREATE INDEX authsrv_projectgroupnamespacerole_group_id_15ba5c48 ON authsrv_projectgroupnamespacerole USING btree (group_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_name_0d0cc737 ON authsrv_projectgroupnamespacerole USING btree (name);
 
-CREATE INDEX authsrv_projectgroupnamespacerole_name_0d0cc737 ON authsrv_projectgroupnamespacerole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_name_0d0cc737_like ON authsrv_projectgroupnamespacerole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_projectgroupnamespacerole_name_0d0cc737_like ON authsrv_projectgroupnamespacerole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_organization_id_0b4626e3 ON authsrv_projectgroupnamespacerole USING btree (organization_id);
 
-CREATE INDEX authsrv_projectgroupnamespacerole_organization_id_0b4626e3 ON authsrv_projectgroupnamespacerole USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_partner_id_698d3c06 ON authsrv_projectgroupnamespacerole USING btree (partner_id);
 
-CREATE INDEX authsrv_projectgroupnamespacerole_partner_id_698d3c06 ON authsrv_projectgroupnamespacerole USING btree (partner_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_project_id_70668f98 ON authsrv_projectgroupnamespacerole USING btree (project_id);
 
-CREATE INDEX authsrv_projectgroupnamespacerole_project_id_70668f98 ON authsrv_projectgroupnamespacerole USING btree (project_id);
-
-CREATE INDEX authsrv_projectgroupnamespacerole_role_id_75ee38a5 ON authsrv_projectgroupnamespacerole USING btree (role_id);
-
-ALTER TABLE ONLY authsrv_projectgroupnamespacerole
-    ADD CONSTRAINT authsrv_projectgroup_group_id_15ba5c48_fk_authsrv_g FOREIGN KEY (group_id) 
-    REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgroupnamespacerole
-    ADD CONSTRAINT authsrv_projectgroup_organization_id_0b4626e3_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgroupnamespacerole
-    ADD CONSTRAINT authsrv_projectgroup_partner_id_698d3c06_fk_authsrv_p FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgroupnamespacerole
-    ADD CONSTRAINT authsrv_projectgroup_project_id_70668f98_fk_authsrv_p FOREIGN KEY (project_id) 
-    REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgroupnamespacerole
-    ADD CONSTRAINT authsrv_projectgroup_role_id_75ee38a5_fk_authsrv_r FOREIGN KEY (role_id) 
-    REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_projectgroupnamespacerole_role_id_75ee38a5 ON authsrv_projectgroupnamespacerole USING btree (role_id);

--- a/persistence/migrations/admindb/000013_authsrv_projectgrouprole.up.sql
+++ b/persistence/migrations/admindb/000013_authsrv_projectgrouprole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_projectgrouprole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -7,45 +7,23 @@ CREATE TABLE IF NOT EXISTS authsrv_projectgrouprole (
     trash boolean NOT NULL,
     "default" boolean NOT NULL,
     active boolean NOT NULL,
-    group_id uuid NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
-    project_id uuid,
-    role_id uuid NOT NULL
+    group_id uuid NOT NULL REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
+    project_id uuid REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED,
+    role_id uuid NOT NULL REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_projectgrouprole ADD CONSTRAINT authsrv_projectgrouprole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_group_id_bda11774 ON authsrv_projectgrouprole USING btree (group_id);
 
-CREATE INDEX authsrv_projectgrouprole_group_id_bda11774 ON authsrv_projectgrouprole USING btree (group_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_name_34417538 ON authsrv_projectgrouprole USING btree (name);
 
-CREATE INDEX authsrv_projectgrouprole_name_34417538 ON authsrv_projectgrouprole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_name_34417538_like ON authsrv_projectgrouprole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_projectgrouprole_name_34417538_like ON authsrv_projectgrouprole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_organization_id_f149c4f0 ON authsrv_projectgrouprole USING btree (organization_id);
 
-CREATE INDEX authsrv_projectgrouprole_organization_id_f149c4f0 ON authsrv_projectgrouprole USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_partner_id_72198047 ON authsrv_projectgrouprole USING btree (partner_id);
 
-CREATE INDEX authsrv_projectgrouprole_partner_id_72198047 ON authsrv_projectgrouprole USING btree (partner_id);
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_project_id_5c5917b5 ON authsrv_projectgrouprole USING btree (project_id);
 
-CREATE INDEX authsrv_projectgrouprole_project_id_5c5917b5 ON authsrv_projectgrouprole USING btree (project_id);
-
-CREATE INDEX authsrv_projectgrouprole_role_id_d930456e ON authsrv_projectgrouprole USING btree (role_id);
-
-ALTER TABLE ONLY authsrv_projectgrouprole
-    ADD CONSTRAINT authsrv_projectgroup_organization_id_f149c4f0_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgrouprole
-    ADD CONSTRAINT authsrv_projectgroup_partner_id_72198047_fk_authsrv_p FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgrouprole
-    ADD CONSTRAINT authsrv_projectgroup_project_id_5c5917b5_fk_authsrv_p FOREIGN KEY (project_id) 
-    REFERENCES authsrv_project(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgrouprole
-    ADD CONSTRAINT authsrv_projectgroup_role_id_d930456e_fk_authsrv_r FOREIGN KEY (role_id) 
-    REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_projectgrouprole
-    ADD CONSTRAINT authsrv_projectgrouprole_group_id_bda11774_fk_authsrv_group_id FOREIGN KEY (group_id) 
-    REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_projectgrouprole_role_id_d930456e ON authsrv_projectgrouprole USING btree (role_id);

--- a/persistence/migrations/admindb/000014_authsrv_groupaccount.up.sql
+++ b/persistence/migrations/admindb/000014_authsrv_groupaccount.up.sql
@@ -1,25 +1,19 @@
 CREATE TABLE IF NOT EXISTS authsrv_groupaccount (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
     trash boolean NOT NULL,
     account_id uuid NOT NULL,
-    group_id uuid NOT NULL,
+    group_id uuid NOT NULL REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED,
     active boolean not null default true
 );
 
-ALTER TABLE ONLY authsrv_groupaccount ADD CONSTRAINT authsrv_groupaccount_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_groupaccount_account_id_041e4e98 ON authsrv_groupaccount USING btree (account_id);
 
-CREATE INDEX authsrv_groupaccount_account_id_041e4e98 ON authsrv_groupaccount USING btree (account_id);
+CREATE INDEX IF NOT EXISTS authsrv_groupaccount_group_id_c67750ef ON authsrv_groupaccount USING btree (group_id);
 
-CREATE INDEX authsrv_groupaccount_group_id_c67750ef ON authsrv_groupaccount USING btree (group_id);
+CREATE INDEX IF NOT EXISTS authsrv_groupaccount_name_d17de056 ON authsrv_groupaccount USING btree (name);
 
-CREATE INDEX authsrv_groupaccount_name_d17de056 ON authsrv_groupaccount USING btree (name);
-
-CREATE INDEX authsrv_groupaccount_name_d17de056_like ON authsrv_groupaccount USING btree (name varchar_pattern_ops);
-
-ALTER TABLE ONLY authsrv_groupaccount
-    ADD CONSTRAINT authsrv_groupaccount_group_id_c67750ef_fk_authsrv_group_id FOREIGN KEY (group_id) 
-    REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_groupaccount_name_d17de056_like ON authsrv_groupaccount USING btree (name varchar_pattern_ops);

--- a/persistence/migrations/admindb/000015_authsrv_grouprole.up.sql
+++ b/persistence/migrations/admindb/000015_authsrv_grouprole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_grouprole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -7,38 +7,20 @@ CREATE TABLE IF NOT EXISTS authsrv_grouprole (
     trash boolean NOT NULL,
     "default" boolean NOT NULL,
     active boolean NOT NULL,
-    group_id uuid NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
-    role_id uuid NOT NULL
+    group_id uuid NOT NULL REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
+    role_id uuid NOT NULL REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_grouprole ADD CONSTRAINT authsrv_grouprole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_grouprole_group_id_2f1402a5 ON authsrv_grouprole USING btree (group_id);
 
-CREATE INDEX authsrv_grouprole_group_id_2f1402a5 ON authsrv_grouprole USING btree (group_id);
+CREATE INDEX IF NOT EXISTS authsrv_grouprole_name_3810bc7c ON authsrv_grouprole USING btree (name);
 
-CREATE INDEX authsrv_grouprole_name_3810bc7c ON authsrv_grouprole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_grouprole_name_3810bc7c_like ON authsrv_grouprole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_grouprole_name_3810bc7c_like ON authsrv_grouprole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_grouprole_organization_id_9e77495d ON authsrv_grouprole USING btree (organization_id);
 
-CREATE INDEX authsrv_grouprole_organization_id_9e77495d ON authsrv_grouprole USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_grouprole_partner_id_f27b027a ON authsrv_grouprole USING btree (partner_id);
 
-CREATE INDEX authsrv_grouprole_partner_id_f27b027a ON authsrv_grouprole USING btree (partner_id);
-
-CREATE INDEX authsrv_grouprole_role_id_786f31f9 ON authsrv_grouprole USING btree (role_id);
-
-ALTER TABLE ONLY authsrv_grouprole
-    ADD CONSTRAINT authsrv_grouprole_group_id_2f1402a5_fk_authsrv_group_id FOREIGN KEY (group_id) 
-    REFERENCES authsrv_group(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_grouprole
-    ADD CONSTRAINT authsrv_grouprole_organization_id_9e77495d_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_grouprole
-    ADD CONSTRAINT authsrv_grouprole_partner_id_f27b027a_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_grouprole
-    ADD CONSTRAINT authsrv_grouprole_role_id_786f31f9_fk_authsrv_resourcerole_id FOREIGN KEY (role_id) 
-    REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_grouprole_role_id_786f31f9 ON authsrv_grouprole USING btree (role_id);

--- a/persistence/migrations/admindb/000016_authsrv_accountresourcerole.up.sql
+++ b/persistence/migrations/admindb/000016_authsrv_accountresourcerole.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_accountresourcerole (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -8,33 +8,19 @@ CREATE TABLE IF NOT EXISTS authsrv_accountresourcerole (
     "default" boolean NOT NULL,
     active boolean NOT NULL,
     account_id uuid NOT NULL,
-    organization_id uuid,
-    partner_id uuid,
-    role_id uuid NOT NULL
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
+    role_id uuid NOT NULL REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_accountresourcerole ADD CONSTRAINT authsrv_accountresourcerole_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_accountresourcerole_account_id_229069ae ON authsrv_accountresourcerole USING btree (account_id);
 
-CREATE INDEX authsrv_accountresourcerole_account_id_229069ae ON authsrv_accountresourcerole USING btree (account_id);
+CREATE INDEX IF NOT EXISTS authsrv_accountresourcerole_name_e1f3d8a0 ON authsrv_accountresourcerole USING btree (name);
 
-CREATE INDEX authsrv_accountresourcerole_name_e1f3d8a0 ON authsrv_accountresourcerole USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_accountresourcerole_name_e1f3d8a0_like ON authsrv_accountresourcerole USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_accountresourcerole_name_e1f3d8a0_like ON authsrv_accountresourcerole USING btree (name varchar_pattern_ops);
+CREATE INDEX IF NOT EXISTS authsrv_accountresourcerole_organization_id_22bb772c ON authsrv_accountresourcerole USING btree (organization_id);
 
-CREATE INDEX authsrv_accountresourcerole_organization_id_22bb772c ON authsrv_accountresourcerole USING btree (organization_id);
+CREATE INDEX IF NOT EXISTS authsrv_accountresourcerole_partner_id_8e96aff4 ON authsrv_accountresourcerole USING btree (partner_id);
 
-CREATE INDEX authsrv_accountresourcerole_partner_id_8e96aff4 ON authsrv_accountresourcerole USING btree (partner_id);
-
-CREATE INDEX authsrv_accountresourcerole_role_id_769ec143 ON authsrv_accountresourcerole USING btree (role_id);
-
-ALTER TABLE ONLY authsrv_accountresourcerole
-    ADD CONSTRAINT authsrv_accountresou_organization_id_22bb772c_fk_authsrv_o FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_accountresourcerole
-    ADD CONSTRAINT authsrv_accountresou_partner_id_8e96aff4_fk_authsrv_p FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_accountresourcerole
-    ADD CONSTRAINT authsrv_accountresou_role_id_769ec143_fk_authsrv_r FOREIGN KEY (role_id) 
-    REFERENCES authsrv_resourcerole(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_accountresourcerole_role_id_769ec143 ON authsrv_accountresourcerole USING btree (role_id);

--- a/persistence/migrations/admindb/000017_authsrv_template.up.sql
+++ b/persistence/migrations/admindb/000017_authsrv_template.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_template (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -7,17 +7,11 @@ CREATE TABLE IF NOT EXISTS authsrv_template (
     trash boolean NOT NULL,
     type character varying(64) NOT NULL,
     source text NOT NULL,
-    partner_id uuid NOT NULL
+    partner_id uuid NOT NULL REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-ALTER TABLE ONLY authsrv_template ADD CONSTRAINT authsrv_template_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_template_name_274ef2d3 ON authsrv_template USING btree (name);
 
-CREATE INDEX authsrv_template_name_274ef2d3 ON authsrv_template USING btree (name);
+CREATE INDEX IF NOT EXISTS authsrv_template_name_274ef2d3_like ON authsrv_template USING btree (name varchar_pattern_ops);
 
-CREATE INDEX authsrv_template_name_274ef2d3_like ON authsrv_template USING btree (name varchar_pattern_ops);
-
-CREATE INDEX authsrv_template_partner_id_2fcb0ded ON authsrv_template USING btree (partner_id);
-
-ALTER TABLE ONLY authsrv_template
-    ADD CONSTRAINT authsrv_template_partner_id_2fcb0ded_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_template_partner_id_2fcb0ded ON authsrv_template USING btree (partner_id);

--- a/persistence/migrations/admindb/000018_sentry_bootstrap_infra.up.sql
+++ b/persistence/migrations/admindb/000018_sentry_bootstrap_infra.up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS sentry_bootstrap_infra (
     -- database id fields
-    name character varying(256) NOT NULL,
+    name character varying(256) PRIMARY KEY,
     organization_id uuid,
     partner_id uuid,
     project_id uuid,
@@ -14,10 +14,6 @@ CREATE TABLE IF NOT EXISTS sentry_bootstrap_infra (
     annotations jsonb NOT NULL DEFAULT '{}' ::jsonb,
     -- infra spec
     ca_cert text NOT NULL,
-    ca_key text NOT NULL
+    ca_key text NOT NULL,
+    CONSTRAINT sentry_bootstrap_infra_name_partner_id_organization_id_proj_key UNIQUE (name, partner_id, organization_id, project_id)
 );
-
-ALTER TABLE ONLY sentry_bootstrap_infra ADD CONSTRAINT sentry_bootstrap_infra_pkey PRIMARY KEY (name);
-
-ALTER TABLE ONLY sentry_bootstrap_infra
-    ADD CONSTRAINT sentry_bootstrap_infra_name_partner_id_organization_id_proj_key UNIQUE (name, partner_id, organization_id, project_id);

--- a/persistence/migrations/admindb/000019_sentry_bootstrap_agent_template.up.sql
+++ b/persistence/migrations/admindb/000019_sentry_bootstrap_agent_template.up.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS sentry_bootstrap_agent_template (
     -- database id fields
-    name character varying(256) NOT NULL,
+    name character varying(256) PRIMARY KEY,
     organization_id uuid,
     partner_id uuid,
     project_id uuid,
-    infra_ref character varying(256) NOT NULL,
+    infra_ref character varying(256) NOT NULL REFERENCES sentry_bootstrap_infra(name),
     -- paralus meta fields
     display_name character varying(256) NOT NULL,
     created_at timestamp WITH time zone NOT NULL,
@@ -19,19 +19,8 @@ CREATE TABLE IF NOT EXISTS sentry_bootstrap_agent_template (
     auto_approve boolean NOT NULL DEFAULT FALSE,
     template_type character varying(512) NOT NULL,
     hosts jsonb NOT NULL DEFAULT '[]'::jsonb,
-    token character varying(256) NOT NULL,
+    token character varying(256) NOT NULL UNIQUE,
     incluster_template text NOT NULL,
-    outofcluster_template text NOT NULL
+    outofcluster_template text NOT NULL,
+    CONSTRAINT sentry_bootstrap_agent_templa_name_partner_id_organization__key UNIQUE (name, partner_id, organization_id, project_id)
 );
-
-ALTER TABLE ONLY sentry_bootstrap_agent_template ADD CONSTRAINT sentry_bootstrap_agent_template_pkey PRIMARY KEY (name);
-
-ALTER TABLE ONLY sentry_bootstrap_agent_template
-    ADD CONSTRAINT sentry_bootstrap_agent_templa_name_partner_id_organization__key UNIQUE (name, partner_id, organization_id, project_id);
-
-ALTER TABLE ONLY sentry_bootstrap_agent_template
-    ADD CONSTRAINT sentry_bootstrap_agent_template_token_key UNIQUE (token);
-
-ALTER TABLE ONLY sentry_bootstrap_agent_template
-    ADD CONSTRAINT sentry_bootstrap_agent_template_infra_ref_fkey FOREIGN KEY (infra_ref) 
-    REFERENCES sentry_bootstrap_infra(name);

--- a/persistence/migrations/admindb/000020_sentry_bootstrap_agent.up.sql
+++ b/persistence/migrations/admindb/000020_sentry_bootstrap_agent.up.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS sentry_bootstrap_agent (
     -- database id fields
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     organization_id uuid,
     partner_id uuid,
     project_id uuid,
-    template_ref character varying(256) NOT NULL,
+    template_ref character varying(256) NOT NULL REFERENCES sentry_bootstrap_agent_template(name),
     agent_mode character varying(512) NOT NULL,
     -- paralus meta fields
     display_name character varying(256) NOT NULL,
@@ -15,22 +15,11 @@ CREATE TABLE IF NOT EXISTS sentry_bootstrap_agent (
     labels jsonb NOT NULL DEFAULT '{}' ::jsonb,
     annotations jsonb NOT NULL DEFAULT '{}' ::jsonb,
     -- bootstrap token spec fields
-    token character varying(256) NOT NULL,
+    token character varying(256) NOT NULL UNIQUE,
     -- bootstrap token status fields
     token_state character varying(256) NOT NULL,
     ip_address character varying(20) NOT NULL,
     last_checked_in timestamp with time zone,
-    fingerprint character varying(256) NOT NULL
+    fingerprint character varying(256) NOT NULL,
+    CONSTRAINT sentry_bootstrap_agent_name_templateref_organization_id_partner UNIQUE (name, template_ref, organization_id, partner_id, project_id)
 );
-
-ALTER TABLE ONLY sentry_bootstrap_agent ADD CONSTRAINT sentry_bootstrap_agent_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY sentry_bootstrap_agent
-    ADD CONSTRAINT sentry_bootstrap_agent_name_templateref_organization_id_partner UNIQUE (name, template_ref, organization_id, partner_id, project_id);
-
-ALTER TABLE ONLY sentry_bootstrap_agent
-    ADD CONSTRAINT sentry_bootstrap_agent_token_key UNIQUE (token);
-
-ALTER TABLE ONLY sentry_bootstrap_agent
-    ADD CONSTRAINT sentry_bootstrap_agent_template_ref_fkey FOREIGN KEY (template_ref) 
-    REFERENCES sentry_bootstrap_agent_template(name);

--- a/persistence/migrations/admindb/000024_sentry_kubeconfig_revocation.up.sql
+++ b/persistence/migrations/admindb/000024_sentry_kubeconfig_revocation.up.sql
@@ -1,14 +1,10 @@
 CREATE TABLE IF NOT EXISTS sentry_kubeconfig_revocation (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     organization_id uuid NOT NULL,
     partner_id uuid NOT NULL,
     account_id uuid NOT NULL,
     revoked_at timestamp WITH time zone,
     created_at timestamp WITH time zone NOT NULL,
-    is_sso_user boolean default FALSE
+    is_sso_user boolean default FALSE,
+    CONSTRAINT sentry_kubeconfig_revocation_acc_org_sso_key UNIQUE (organization_id, account_id, is_sso_user)
 );
-
-ALTER TABLE ONLY sentry_kubeconfig_revocation ADD CONSTRAINT sentry_kubeconfig_revocation_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY sentry_kubeconfig_revocation
-    ADD CONSTRAINT sentry_kubeconfig_revocation_acc_org_sso_key UNIQUE (organization_id, account_id, is_sso_user);

--- a/persistence/migrations/admindb/000025_sentry_kubeconfig_setting.up.sql
+++ b/persistence/migrations/admindb/000025_sentry_kubeconfig_setting.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS sentry_kubeconfig_setting (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     organization_id uuid NOT NULL,
     partner_id uuid NOT NULL,
     account_id uuid NOT NULL,
@@ -16,10 +16,6 @@ CREATE TABLE IF NOT EXISTS sentry_kubeconfig_setting (
     disable_web_kubectl boolean default false,
     disable_cli_kubectl boolean default false,
     enable_privaterelay boolean default false,
-    enforce_orgadmin_secret_access boolean default false
+    enforce_orgadmin_secret_access boolean default false,
+    CONSTRAINT sentry_kubeconfig_setting_acc_org_sso_key UNIQUE (organization_id, account_id, is_sso_user)
 );
-
-ALTER TABLE ONLY sentry_kubeconfig_setting ADD CONSTRAINT sentry_kubeconfig_setting_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY sentry_kubeconfig_setting
-    ADD CONSTRAINT sentry_kubeconfig_setting_acc_org_sso_key UNIQUE (organization_id, account_id, is_sso_user);

--- a/persistence/migrations/admindb/000027_sentry_kubectl_cluster_settings.up.sql
+++ b/persistence/migrations/admindb/000027_sentry_kubectl_cluster_settings.up.sql
@@ -1,15 +1,11 @@
 CREATE TABLE IF NOT EXISTS sentry_kubectl_cluster_settings (
-    name varchar NOT NULL,
+    name varchar PRIMARY KEY,
     organization_id uuid NOT NULL,
     partner_id uuid NOT NULL,
     disable_web_kubectl boolean NOT NULL DEFAULT FALSE,
     disable_cli_kubectl boolean NOT NULL DEFAULT FALSE,
     modified_at timestamp WITH time zone,
     created_at timestamp WITH time zone NOT NULL,
-    deleted_at timestamp WITH time zone
+    deleted_at timestamp WITH time zone,
+    CONSTRAINT sentry_kubectl_cluster_settin_name_partner_id_organization__key UNIQUE (name, partner_id, organization_id)
 );
-
-ALTER TABLE ONLY sentry_kubectl_cluster_settings ADD CONSTRAINT sentry_kubectl_cluster_settings_pkey PRIMARY KEY (name);
-
-ALTER TABLE ONLY sentry_kubectl_cluster_settings
-    ADD CONSTRAINT sentry_kubectl_cluster_settin_name_partner_id_organization__key UNIQUE (name, partner_id, organization_id);

--- a/persistence/migrations/admindb/000028_authsrv_idp.up.sql
+++ b/persistence/migrations/admindb/000028_authsrv_idp.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_idp (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS authsrv_idp (
     idp_name character varying(256) NOT NULL,
     domain character varying(64) NOT NULL,
     trash boolean NOT NULL,
-    organization_id uuid,
-    partner_id uuid NOT NULL,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid NOT NULL REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
     sso_url character varying(256),
     idp_cert text,
     sp_cert text,
@@ -17,23 +17,12 @@ CREATE TABLE IF NOT EXISTS authsrv_idp (
     metadata_filename character varying(64),
     metadata bytea,
     group_attribute_name text,
-    is_sae_enabled boolean default false
+    is_sae_enabled boolean default false,
+    CONSTRAINT authsrv_idp_partner_id_domain_5669b152_uniq UNIQUE (partner_id, domain)
 );
 
-ALTER TABLE ONLY authsrv_idp ADD CONSTRAINT authsrv_idp_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS authsrv_idp_organization_id_4219d6ee ON authsrv_idp USING btree (organization_id);
 
-ALTER TABLE ONLY authsrv_idp ADD CONSTRAINT authsrv_idp_partner_id_domain_5669b152_uniq UNIQUE (partner_id, domain);
+CREATE INDEX IF NOT EXISTS authsrv_idp_partner_id_beb7c8df ON authsrv_idp USING btree (partner_id);
 
-CREATE INDEX authsrv_idp_organization_id_4219d6ee ON authsrv_idp USING btree (organization_id);
-
-CREATE INDEX authsrv_idp_partner_id_beb7c8df ON authsrv_idp USING btree (partner_id);
-
-CREATE INDEX authsrv_idp_partner_id_domain_5669b152_idx ON authsrv_idp USING btree (partner_id, domain);
-
-ALTER TABLE ONLY authsrv_idp
-    ADD CONSTRAINT authsrv_idp_organization_id_4219d6ee_fk_authsrv_organization_id FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_idp
-    ADD CONSTRAINT authsrv_idp_partner_id_beb7c8df_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_idp_partner_id_domain_5669b152_idx ON authsrv_idp USING btree (partner_id, domain);

--- a/persistence/migrations/admindb/000029_authsrv_oidc_provider.up.sql
+++ b/persistence/migrations/admindb/000029_authsrv_oidc_provider.up.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS authsrv_oidc_provider (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     description character varying(512) NOT NULL,
-    organization_id uuid,
-    partner_id uuid NOT NULL,
+    organization_id uuid REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED,
+    partner_id uuid NOT NULL REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
 
@@ -21,20 +21,10 @@ CREATE TABLE IF NOT EXISTS authsrv_oidc_provider (
     trash boolean NOT NULL
 );
 
-ALTER TABLE ONLY authsrv_oidc_provider ADD CONSTRAINT authsrv_oidc_provider_pkey PRIMARY KEY (id);
+CREATE UNIQUE INDEX IF NOT EXISTS authsrv_oidc_provider_issuer_url ON authsrv_oidc_provider (issuer_url) WHERE trash IS false;
 
-CREATE UNIQUE index authsrv_oidc_provider_issuer_url ON authsrv_oidc_provider (issuer_url) WHERE trash IS false;
+CREATE UNIQUE INDEX IF NOT EXISTS authsrv_oidc_provider_name ON authsrv_oidc_provider (name) WHERE trash IS false;
 
-CREATE UNIQUE index authsrv_oidc_provider_name ON authsrv_oidc_provider (name) WHERE trash IS false;
+CREATE INDEX IF NOT EXISTS authsrv_oidc_provider_organization_id_4219d6ee ON authsrv_oidc_provider USING btree (organization_id);
 
-CREATE INDEX authsrv_oidc_provider_organization_id_4219d6ee ON authsrv_oidc_provider USING btree (organization_id);
-
-CREATE INDEX authsrv_oidc_provider_partner_id_beb7c8df ON authsrv_oidc_provider USING btree (partner_id);
-
-ALTER TABLE ONLY authsrv_oidc_provider
-    ADD CONSTRAINT authsrv_oidc_provider_organization_id_4219d6ee_fk_authsrv_organization_id FOREIGN KEY (organization_id) 
-    REFERENCES authsrv_organization(id) DEFERRABLE INITIALLY DEFERRED;
-
-ALTER TABLE ONLY authsrv_oidc_provider
-    ADD CONSTRAINT authsrv_oidc_provider_partner_id_beb7c8df_fk_authsrv_partner_id FOREIGN KEY (partner_id) 
-    REFERENCES authsrv_partner(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS authsrv_oidc_provider_partner_id_beb7c8df ON authsrv_oidc_provider USING btree (partner_id);

--- a/persistence/migrations/admindb/000030_pg_oidc_provider_triggers.up.sql
+++ b/persistence/migrations/admindb/000030_pg_oidc_provider_triggers.up.sql
@@ -1,20 +1,18 @@
-CREATE FUNCTION providers_after_change_trigger()
-RETURNS TRIGGER AS $$
-BEGIN
-  PERFORM pg_notify('provider:changed', '');
-  RETURN NULL;
-END;
-$$
-LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION providers_after_change_trigger() RETURNS TRIGGER AS $$
+  BEGIN
+    PERFORM pg_notify('provider:changed', '');
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
 
-CREATE TRIGGER providers_updated
-AFTER UPDATE ON authsrv_oidc_provider
-FOR EACH ROW EXECUTE PROCEDURE providers_after_change_trigger();
+CREATE OR REPLACE TRIGGER providers_updated
+  AFTER UPDATE ON authsrv_oidc_provider
+  FOR EACH ROW EXECUTE PROCEDURE providers_after_change_trigger();
 
-CREATE TRIGGER providers_inserted
-AFTER INSERT ON authsrv_oidc_provider
-FOR EACH ROW EXECUTE PROCEDURE providers_after_change_trigger();
+CREATE OR REPLACE TRIGGER providers_inserted
+  AFTER INSERT ON authsrv_oidc_provider
+  FOR EACH ROW EXECUTE PROCEDURE providers_after_change_trigger();
 
-CREATE TRIGGER providers_deleted
-AFTER DELETE ON authsrv_oidc_provider
-FOR EACH ROW EXECUTE PROCEDURE providers_after_change_trigger();
+CREATE OR REPLACE TRIGGER providers_deleted
+  AFTER DELETE ON authsrv_oidc_provider
+  FOR EACH ROW EXECUTE PROCEDURE providers_after_change_trigger();

--- a/persistence/migrations/admindb/000031_cluster_metro.up.sql
+++ b/persistence/migrations/admindb/000031_cluster_metro.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS cluster_metro (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name character varying(256) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     modified_at timestamp with time zone NOT NULL,
@@ -14,5 +14,3 @@ CREATE TABLE IF NOT EXISTS cluster_metro (
     organization_id uuid,
     partner_id uuid NOT NULL
 );
-
-ALTER TABLE ONLY cluster_metro ADD CONSTRAINT cluster_metro_pkey PRIMARY KEY (id);

--- a/persistence/migrations/admindb/000033_cluster_tokens.up.sql
+++ b/persistence/migrations/admindb/000033_cluster_tokens.up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS cluster_tokens (
     id uuid NOT NULL default uuid_generate_v4(),
-    name varchar NOT NULL,
+    name varchar PRIMARY KEY,
     organization_id uuid not null,
     partner_id uuid not null,
     project_id uuid not null,
@@ -14,5 +14,3 @@ CREATE TABLE IF NOT EXISTS cluster_tokens (
     token_type varchar NOT NULL,
     state varchar NOT NULL
 );
-
-ALTER TABLE ONLY cluster_tokens ADD CONSTRAINT cluster_tokens_pkey PRIMARY KEY (name);

--- a/persistence/migrations/admindb/000034_cluster_clusters.up.sql
+++ b/persistence/migrations/admindb/000034_cluster_clusters.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS cluster_clusters (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     organization_id uuid not null,
     partner_id uuid not null,
     project_id uuid not null,
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS cluster_clusters (
     blueprint_ref varchar NOT NULL default '',
     cluster_type text,
     override_selector varchar NOT NULL default '',
-    token varchar not null,
+    token varchar not null REFERENCES cluster_tokens(name) DEFERRABLE INITIALLY DEFERRED,
     conditions jsonb NOT NULL default '[]'::jsonb,
     published_blueprint varchar NOT NULL default '',
     system_task_count integer NOT NULL DEFAULT 0,
@@ -26,14 +26,8 @@ CREATE TABLE IF NOT EXISTS cluster_clusters (
     proxy_config jsonb
 );
 
-ALTER TABLE ONLY cluster_clusters ADD CONSTRAINT cluster_clusters_pkey PRIMARY KEY (id);
+CREATE INDEX IF NOT EXISTS cluster_clusters_name_organization_id_partner_id_key ON cluster_clusters USING btree (name, organization_id, partner_id);
 
-CREATE INDEX cluster_clusters_name_organization_id_partner_id_key ON cluster_clusters USING btree (name, organization_id, partner_id);
+CREATE INDEX IF NOT EXISTS idx_cluster_blueprint ON cluster_clusters USING btree (blueprint_ref, published_blueprint);
 
-CREATE INDEX idx_cluster_blueprint ON cluster_clusters USING btree (blueprint_ref, published_blueprint);
-
-CREATE INDEX idx_clusters_labels ON cluster_clusters USING GIN (labels jsonb_path_ops);
-
-ALTER TABLE ONLY cluster_clusters
-    ADD CONSTRAINT cluster_clusters_token_fkey FOREIGN KEY (token) 
-    REFERENCES cluster_tokens(name) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS idx_clusters_labels ON cluster_clusters USING GIN (labels jsonb_path_ops);

--- a/persistence/migrations/admindb/000035_cluster_project_cluster.up.sql
+++ b/persistence/migrations/admindb/000035_cluster_project_cluster.up.sql
@@ -1,11 +1,7 @@
 CREATE TABLE IF NOT EXISTS cluster_project_cluster (
     project_id uuid NOT NULL,
-    cluster_id uuid NOT NULL,
+    cluster_id uuid NOT NULL REFERENCES cluster_clusters(id) DEFERRABLE INITIALLY DEFERRED,
     trash boolean NOT NULL default false
 );
 
-CREATE INDEX cluster_project_cluster_project_id_cluster_id_key ON cluster_project_cluster USING btree (project_id, cluster_id);
-
-ALTER TABLE ONLY cluster_project_cluster
-    ADD CONSTRAINT cluster_project_cluster_cluster_id_fkey FOREIGN KEY (cluster_id) 
-    REFERENCES cluster_clusters(id) DEFERRABLE INITIALLY DEFERRED;
+CREATE INDEX IF NOT EXISTS cluster_project_cluster_project_id_cluster_id_key ON cluster_project_cluster USING btree (project_id, cluster_id);

--- a/persistence/migrations/admindb/000036_cluster_namespaces.up.sql
+++ b/persistence/migrations/admindb/000036_cluster_namespaces.up.sql
@@ -1,16 +1,11 @@
 CREATE TABLE IF NOT EXISTS cluster_namespaces (
-    cluster_id uuid NOT NULL,
+    cluster_id uuid NOT NULL REFERENCES cluster_clusters(id) DEFERRABLE INITIALLY DEFERRED,
     name varchar NOT NULL,
     hash varchar NOT NULL,
     deleted_at timestamp WITH time zone,
     type varchar not null,
     namespace jsonb not null,
     conditions jsonb not null default '[]'::jsonb,
-    status jsonb not null default '{}'::jsonb
+    status jsonb not null default '{}'::jsonb,
+    PRIMARY KEY (cluster_id, name)
 );
-
-ALTER TABLE ONLY cluster_namespaces ADD CONSTRAINT cluster_namespaces_pkey PRIMARY KEY (cluster_id, name);
-
-ALTER TABLE ONLY cluster_namespaces
-    ADD CONSTRAINT cluster_project_cluster_cluster_id_fkey FOREIGN KEY (cluster_id) 
-    REFERENCES cluster_clusters(id) DEFERRABLE INITIALLY DEFERRED;

--- a/persistence/migrations/admindb/000037_authsrv_apikey.up.sql
+++ b/persistence/migrations/admindb/000037_authsrv_apikey.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS authsrv_apikey (
-    id uuid NOT NULL default uuid_generate_v4(),
+    id uuid default uuid_generate_v4() PRIMARY KEY,
     name varchar NOT NULL,
     description varchar NOT NULL,
     created_at timestamp WITH time zone NOT NULL,
@@ -12,5 +12,3 @@ CREATE TABLE IF NOT EXISTS authsrv_apikey (
     secret_migration varchar NOT NULL,
     secret text not null
 );
-
-ALTER TABLE ONLY authsrv_apikey ADD CONSTRAINT authsrv_apikey_pkey PRIMARY KEY (id);

--- a/persistence/migrations/admindb/000038_pg_identities_triggers.up.sql
+++ b/persistence/migrations/admindb/000038_pg_identities_triggers.up.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION identities_after_change() RETURNS TRIGGER AS $$
   END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER trigger_identities_update
+CREATE OR REPLACE TRIGGER trigger_identities_update
   AFTER INSERT OR UPDATE OR DELETE
   ON identities
   FOR EACH ROW

--- a/persistence/migrations/admindb/000039_cluster_description_column.down.sql
+++ b/persistence/migrations/admindb/000039_cluster_description_column.down.sql
@@ -1,2 +1,1 @@
-ALTER TABLE cluster_clusters
-DROP COLUMN IF EXISTS description;
+ALTER TABLE cluster_clusters DROP COLUMN IF EXISTS description;

--- a/persistence/migrations/admindb/000039_cluster_description_column.up.sql
+++ b/persistence/migrations/admindb/000039_cluster_description_column.up.sql
@@ -1,2 +1,1 @@
-ALTER TABLE cluster_clusters
-ADD COLUMN description varchar;
+ALTER TABLE cluster_clusters ADD COLUMN IF NOT EXISTS description varchar;


### PR DESCRIPTION
### What does this PR change?

Make all admindb migration queries re-entrance so re-running migration would not fail.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [ ] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
