### PR TITLE
add yaml marshal/unmarshal for enums

### DIFF
--- a/cmd/generate-enum/main.go
+++ b/cmd/generate-enum/main.go
@@ -14,6 +14,7 @@ package {{ .PackageName }}
 import (
 	driver "database/sql/driver"
 	bytes "bytes"
+	"fmt"
 )
 
 // Scan converts database string to {{ .EnumName }}
@@ -44,8 +45,29 @@ func (e *{{ .EnumName }}) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalYAML implements the yaml.Marshaler interface 
+func (e {{ .EnumName }}) MarshalYAML() (interface{}, error) {
+	return {{ .EnumName }}_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *{{ .EnumName }}) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := {{ .EnumName }}_value[name]
+	if !ok {
+		return fmt.Errorf("invalid {{ .EnumName }}: %s", name)
+	}
+
+	*e = {{ .EnumName }}(value)
+	return nil
+}
+
 // implement proto enum interface
-func (e {{ .EnumName }}) IsEnum()  {
+func (e {{ .EnumName }}) IsEnum() {
 }
 
 `

--- a/proto/types/commonpb/v3/paralusconditionstatus.enum.go
+++ b/proto/types/commonpb/v3/paralusconditionstatus.enum.go
@@ -4,6 +4,7 @@ package commonv3
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to ParalusConditionStatus
@@ -37,6 +38,27 @@ func (e *ParalusConditionStatus) UnmarshalJSON(b []byte) error {
 		}
 		*e = ParalusConditionStatus(ParalusConditionStatus_value[string(b[1:length])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e ParalusConditionStatus) MarshalYAML() (interface{}, error) {
+	return ParalusConditionStatus_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *ParalusConditionStatus) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := ParalusConditionStatus_value[name]
+	if !ok {
+		return fmt.Errorf("invalid ParalusConditionStatus: %s", name)
+	}
+
+	*e = ParalusConditionStatus(value)
 	return nil
 }
 

--- a/proto/types/infrapb/v3/clusterconditiontype.enum.go
+++ b/proto/types/infrapb/v3/clusterconditiontype.enum.go
@@ -4,6 +4,7 @@ package infrav3
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to ClusterConditionType
@@ -37,6 +38,27 @@ func (e *ClusterConditionType) UnmarshalJSON(b []byte) error {
 		}
 		*e = ClusterConditionType(ClusterConditionType_value[string(b[1:length])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e ClusterConditionType) MarshalYAML() (interface{}, error) {
+	return ClusterConditionType_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *ClusterConditionType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := ClusterConditionType_value[name]
+	if !ok {
+		return fmt.Errorf("invalid ClusterConditionType: %s", name)
+	}
+
+	*e = ClusterConditionType(value)
 	return nil
 }
 

--- a/proto/types/infrapb/v3/clusternodestate.enum.go
+++ b/proto/types/infrapb/v3/clusternodestate.enum.go
@@ -4,6 +4,7 @@ package infrav3
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to ClusterNodeState
@@ -31,6 +32,27 @@ func (e *ClusterNodeState) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = ClusterNodeState(ClusterNodeState_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e ClusterNodeState) MarshalYAML() (interface{}, error) {
+	return ClusterNodeState_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *ClusterNodeState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := ClusterNodeState_value[name]
+	if !ok {
+		return fmt.Errorf("invalid ClusterNodeState: %s", name)
+	}
+
+	*e = ClusterNodeState(value)
 	return nil
 }
 

--- a/proto/types/infrapb/v3/clustersharemode.enum.go
+++ b/proto/types/infrapb/v3/clustersharemode.enum.go
@@ -4,6 +4,7 @@ package infrav3
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to ClusterShareMode
@@ -31,6 +32,27 @@ func (e *ClusterShareMode) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = ClusterShareMode(ClusterShareMode_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e ClusterShareMode) MarshalYAML() (interface{}, error) {
+	return ClusterShareMode_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *ClusterShareMode) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := ClusterShareMode_value[name]
+	if !ok {
+		return fmt.Errorf("invalid ClusterShareMode: %s", name)
+	}
+
+	*e = ClusterShareMode(value)
 	return nil
 }
 

--- a/proto/types/infrapb/v3/clustertokenstate.enum.go
+++ b/proto/types/infrapb/v3/clustertokenstate.enum.go
@@ -4,6 +4,7 @@ package infrav3
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to ClusterTokenState
@@ -31,6 +32,27 @@ func (e *ClusterTokenState) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = ClusterTokenState(ClusterTokenState_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e ClusterTokenState) MarshalYAML() (interface{}, error) {
+	return ClusterTokenState_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *ClusterTokenState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := ClusterTokenState_value[name]
+	if !ok {
+		return fmt.Errorf("invalid ClusterTokenState: %s", name)
+	}
+
+	*e = ClusterTokenState(value)
 	return nil
 }
 

--- a/proto/types/infrapb/v3/clustertokentype.enum.go
+++ b/proto/types/infrapb/v3/clustertokentype.enum.go
@@ -4,6 +4,7 @@ package infrav3
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to ClusterTokenType
@@ -31,6 +32,27 @@ func (e *ClusterTokenType) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = ClusterTokenType(ClusterTokenType_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e ClusterTokenType) MarshalYAML() (interface{}, error) {
+	return ClusterTokenType_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *ClusterTokenType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := ClusterTokenType_value[name]
+	if !ok {
+		return fmt.Errorf("invalid ClusterTokenType: %s", name)
+	}
+
+	*e = ClusterTokenType(value)
 	return nil
 }
 

--- a/proto/types/sentry/bootstrapagentmode.enum.go
+++ b/proto/types/sentry/bootstrapagentmode.enum.go
@@ -4,6 +4,7 @@ package sentry
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to BootstrapAgentMode
@@ -31,6 +32,27 @@ func (e *BootstrapAgentMode) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = BootstrapAgentMode(BootstrapAgentMode_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e BootstrapAgentMode) MarshalYAML() (interface{}, error) {
+	return BootstrapAgentMode_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *BootstrapAgentMode) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := BootstrapAgentMode_value[name]
+	if !ok {
+		return fmt.Errorf("invalid BootstrapAgentMode: %s", name)
+	}
+
+	*e = BootstrapAgentMode(value)
 	return nil
 }
 

--- a/proto/types/sentry/bootstrapagentstate.enum.go
+++ b/proto/types/sentry/bootstrapagentstate.enum.go
@@ -4,6 +4,7 @@ package sentry
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to BootstrapAgentState
@@ -31,6 +32,27 @@ func (e *BootstrapAgentState) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = BootstrapAgentState(BootstrapAgentState_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e BootstrapAgentState) MarshalYAML() (interface{}, error) {
+	return BootstrapAgentState_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *BootstrapAgentState) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := BootstrapAgentState_value[name]
+	if !ok {
+		return fmt.Errorf("invalid BootstrapAgentState: %s", name)
+	}
+
+	*e = BootstrapAgentState(value)
 	return nil
 }
 

--- a/proto/types/sentry/bootstrapagenttemplatetype.enum.go
+++ b/proto/types/sentry/bootstrapagenttemplatetype.enum.go
@@ -4,6 +4,7 @@ package sentry
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to BootstrapAgentTemplateType
@@ -31,6 +32,27 @@ func (e *BootstrapAgentTemplateType) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = BootstrapAgentTemplateType(BootstrapAgentTemplateType_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e BootstrapAgentTemplateType) MarshalYAML() (interface{}, error) {
+	return BootstrapAgentTemplateType_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *BootstrapAgentTemplateType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := BootstrapAgentTemplateType_value[name]
+	if !ok {
+		return fmt.Errorf("invalid BootstrapAgentTemplateType: %s", name)
+	}
+
+	*e = BootstrapAgentTemplateType(value)
 	return nil
 }
 

--- a/proto/types/sentry/bootstrapagenttype.enum.go
+++ b/proto/types/sentry/bootstrapagenttype.enum.go
@@ -4,6 +4,7 @@ package sentry
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to BootstrapAgentType
@@ -31,6 +32,27 @@ func (e *BootstrapAgentType) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = BootstrapAgentType(BootstrapAgentType_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e BootstrapAgentType) MarshalYAML() (interface{}, error) {
+	return BootstrapAgentType_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *BootstrapAgentType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := BootstrapAgentType_value[name]
+	if !ok {
+		return fmt.Errorf("invalid BootstrapAgentType: %s", name)
+	}
+
+	*e = BootstrapAgentType(value)
 	return nil
 }
 

--- a/proto/types/sentry/bootstrapinfratype.enum.go
+++ b/proto/types/sentry/bootstrapinfratype.enum.go
@@ -4,6 +4,7 @@ package sentry
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to BootstrapInfraType
@@ -31,6 +32,27 @@ func (e *BootstrapInfraType) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = BootstrapInfraType(BootstrapInfraType_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e BootstrapInfraType) MarshalYAML() (interface{}, error) {
+	return BootstrapInfraType_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *BootstrapInfraType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := BootstrapInfraType_value[name]
+	if !ok {
+		return fmt.Errorf("invalid BootstrapInfraType: %s", name)
+	}
+
+	*e = BootstrapInfraType(value)
 	return nil
 }
 

--- a/proto/types/sentry/bootstraptemplatehosttype.enum.go
+++ b/proto/types/sentry/bootstraptemplatehosttype.enum.go
@@ -4,6 +4,7 @@ package sentry
 import (
 	bytes "bytes"
 	driver "database/sql/driver"
+	"fmt"
 )
 
 // Scan converts database string to BootstrapTemplateHostType
@@ -31,6 +32,27 @@ func (e *BootstrapTemplateHostType) UnmarshalJSON(b []byte) error {
 	if b != nil {
 		*e = BootstrapTemplateHostType(BootstrapTemplateHostType_value[string(b[1:len(b)-1])])
 	}
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (e BootstrapTemplateHostType) MarshalYAML() (interface{}, error) {
+	return BootstrapTemplateHostType_name[int32(e)], nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+func (e *BootstrapTemplateHostType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var name string
+	if err := unmarshal(&name); err != nil {
+		return err
+	}
+
+	value, ok := BootstrapTemplateHostType_value[name]
+	if !ok {
+		return fmt.Errorf("invalid BootstrapTemplateHostType: %s", name)
+	}
+
+	*e = BootstrapTemplateHostType(value)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR change?

- This PR introduces custom YAML marshaling and unmarshaling capabilities. With this enhancement, enum values will be represented as descriptive strings instead of numerical values in YAML format. This change is aimed at improving the readability and usability of YAML data containing enum values.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- This PR aimed address https://github.com/paralus/cli/issues/34

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Added tests for this PR
- [x] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
