### PR TITLE
fix: unable to create/update project when roles specified

### DIFF
--- a/pkg/service/project.go
+++ b/pkg/service/project.go
@@ -493,13 +493,12 @@ func (s *projectService) createGroupRoleRelations(ctx context.Context, db bun.ID
 			return &systemv3.Project{}, fmt.Errorf("unable to find group '%v'", grp)
 		}
 		var grpId uuid.UUID
-		var grpName string
 		if g, ok := entity.(*models.Group); ok {
 			grpId = g.ID
-			grpName = g.Name
 		} else {
 			return &systemv3.Project{}, fmt.Errorf("unable to find group '%v'", grp)
 		}
+		grpName := *grp
 
 		org := project.Metadata.Organization
 		switch scope {


### PR DESCRIPTION
### What does this PR change?

Crate or Update project with roles association provided under `projectNamespaceRoles` was failing due to empty group name passed to Casbin. It fixes minor bug getting group name.

### Does the PR depend on any other PRs or Issues? If yes, please list them.

Fixes #136 

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [X] Added tests for this PR
- [X] Formatted the code using `go fmt` (if applicable)
- [X] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
