### PR TITLE
ci: fix golangci-lint timeout error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,3 +53,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          args: --timeout=30m


### PR DESCRIPTION
golangci-lint default timeout is 1m, comparatively in order to completely load all go packages in the repo. This updates timeout to 30m.

### What does this PR change?

None

### Does the PR depend on any other PRs or Issues? If yes, please list them.

None

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [X] Added tests for this PR
- [X] Formatted the code using `go fmt` (if applicable)
- [X] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
