### PR TITLE
fix(rbac): Changes to role permissions in `roles.json` now correctly propagate after initialization.  Fixes #404

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 AS build
+FROM golang:1.25.7 AS build
 LABEL description="Build container"
 
 ENV CGO_ENABLED 0

--- a/Dockerfile.initialize
+++ b/Dockerfile.initialize
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 AS build
+FROM golang:1.25.7 AS build
 LABEL description="Build container"
 ENV CGO_ENABLED 0
 WORKDIR /build

--- a/Dockerfile.synchronizer
+++ b/Dockerfile.synchronizer
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 AS build
+FROM golang:1.25.7 AS build
 LABEL description="Build container"
 
 ENV CGO_ENABLED 0

--- a/_kratos/development/pkg/resources.go
+++ b/_kratos/development/pkg/resources.go
@@ -59,8 +59,8 @@ func CreateIdentity(c *ory.APIClient) *ory.Identity {
 
 	email, _ := RandomCredentials()
 
-	identity, _, err := c.IdentityAPI.CreateIdentity(ctx).CreateIdentityBody(*ory.NewCreateIdentityBody("default", map[string]interface{}{"email": email,}})).Execute()
+	identity, _, err := c.IdentityAPI.CreateIdentity(ctx).CreateIdentityBody(*ory.NewCreateIdentityBody("default", map[string]interface{}{"email": email})).Execute()
 	ExitOnError(err)
-	
+
 	return identity
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/paralus/paralus
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/pkg/service/authz.go
+++ b/pkg/service/authz.go
@@ -204,23 +204,52 @@ func (s *authzService) fromRolePermissionMappingList(ctx context.Context, r *aut
 	}
 
 	res := [][]string{}
+	policySet := make(map[string]struct{}) // DEDUPE MAP
+
 	for i, mapping := range r.GetRolePermissionMappingList() {
+
+		role := mapping.GetRole()
+
 		for _, permission := range mapping.GetPermission() {
-			rules := [][]string{}
+
 			for _, rpm := range s.mappingCache[permission] {
+
 				for _, method := range rpm.methods {
-					rule := []string{rpm.url, mapping.GetRole(), method}
+
+					rule := []string{
+						rpm.url,
+						role,
+						method,
+					}
+
 					for _, field := range rule {
 						if field == "" {
-							return res, fmt.Errorf("index %d: mapping elements do not meet definition", i)
+							return res, fmt.Errorf(
+								"index %d: mapping elements do not meet definition",
+								i,
+							)
 						}
 					}
-					rules = append(rules, rule)
+
+					// Build uniqueness key
+					key := fmt.Sprintf("%s|%s|%s",
+						rpm.url,
+						role,
+						method,
+					)
+
+					// Skip duplicates
+					if _, exists := policySet[key]; exists {
+						continue
+					}
+
+					policySet[key] = struct{}{}
+					res = append(res, rule)
 				}
 			}
-			res = append(res, rules...)
 		}
 	}
+
 	return res, nil
 }
 

--- a/pkg/service/role.go
+++ b/pkg/service/role.go
@@ -89,40 +89,89 @@ func (s *roleService) deleteRolePermissionMapping(ctx context.Context, db bun.ID
 }
 
 func (s *roleService) createRolePermissionMapping(ctx context.Context, db bun.IDB, role *rolev3.Role, ids parsedIds) (*rolev3.Role, error) {
-	perms := role.GetSpec().GetRolepermissions()
 
+	// Deduplicate permissions (safety guard)
+	rawPerms := role.GetSpec().GetRolepermissions()
+
+	permSet := make(map[string]struct{})
+	var perms []string
+
+	for _, p := range rawPerms {
+		if _, exists := permSet[p]; !exists {
+			permSet[p] = struct{}{}
+			perms = append(perms, p)
+		}
+	}
+
+	// fmt.Println("Permissions for role:", role.GetMetadata().GetName())
+	for _, p := range perms {
+		fmt.Println(" -", p)
+	}
+
+	// -----------------------------
+	// Remove existing Casbin mappings (idempotent)
+	_, _ = s.azc.DeleteRolePermissionMappings(
+		ctx,
+		&authzv1.FilteredRolePermissionMapping{
+			Role: role.GetMetadata().GetName(),
+		},
+	)
+
+	// -----------------------------
+	// Remove existing DB mappings (idempotent)
+	_, _ = db.NewDelete().
+		Model((*models.ResourceRolePermission)(nil)).
+		Where("resource_role_id = ?", ids.Id).
+		Exec(ctx)
+
+	// -----------------------------
+	// Build DB mapping entries
 	var items []models.ResourceRolePermission
+
 	for _, p := range perms {
 		entity, err := dao.GetIdByName(ctx, db, p, &models.ResourcePermission{})
 		if err != nil {
 			return role, fmt.Errorf("unable to find role permission '%v'", p)
 		}
-		if prm, ok := entity.(*models.ResourcePermission); ok {
-			items = append(items, models.ResourceRolePermission{
-				ResourceRoleId:       ids.Id,
-				ResourcePermissionId: prm.ID,
-			})
-		} else {
-			return role, fmt.Errorf("unable to find role permission '%v'", p)
+
+		prm, ok := entity.(*models.ResourcePermission)
+		if !ok {
+			return role, fmt.Errorf("invalid permission type for '%v'", p)
 		}
+
+		items = append(items, models.ResourceRolePermission{
+			ResourceRoleId:       ids.Id,
+			ResourcePermissionId: prm.ID,
+		})
 	}
+
+	// -----------------------------
+	// Insert DB mappings
 	if len(items) > 0 {
 		_, err := dao.Create(ctx, db, &items)
 		if err != nil {
 			return role, err
 		}
 
+		// -----------------------------
+		// Create Casbin mappings (clean list)
 		crpm := authzv1.RolePermissionMappingList{
-			RolePermissionMappingList: []*authzv1.RolePermissionMapping{{
-				Role:       role.GetMetadata().GetName(),
-				Permission: role.Spec.Rolepermissions,
-			}},
+			RolePermissionMappingList: []*authzv1.RolePermissionMapping{
+				{
+					Role:       role.GetMetadata().GetName(),
+					Permission: perms, // use deduplicated perms
+				},
+			},
 		}
+
 		success, err := s.azc.CreateRolePermissionMappings(ctx, &crpm)
 		if err != nil || !success.Res {
 			return role, fmt.Errorf("unable to create mapping in authz; %v", err)
 		}
 	}
+
+	// // fmt.Println("Creating Casbin mappings for role:", role.GetMetadata().GetName())
+
 	return role, nil
 }
 
@@ -283,7 +332,7 @@ func (s *roleService) Update(ctx context.Context, role *rolev3.Role) (*rolev3.Ro
 	}
 
 	if rle, ok := entity.(*models.Role); ok {
-		if rle.Builtin {
+		if rle.Builtin && !IsInternalRequest(ctx) {
 			return role, fmt.Errorf("builtin role '%v' cannot be updated", name)
 		}
 		//update role details
@@ -347,7 +396,7 @@ func (s *roleService) Delete(ctx context.Context, role *rolev3.Role) (*rolev3.Ro
 	}
 
 	if rle, ok := entity.(*models.Role); ok {
-		if rle.Builtin {
+		if rle.Builtin && !IsInternalRequest(ctx) {
 			return role, fmt.Errorf("builtin role '%v' cannot be deleted", name)
 		}
 

--- a/scripts/initialize/main.go
+++ b/scripts/initialize/main.go
@@ -277,12 +277,17 @@ func main() {
 		log.Fatal("unable to create org:", err)
 	}
 	// this is used to figure out if the request originated internally so as to not override `builtin`
+	// --------------------
+	// RECONCILE BUILTIN ROLES (Declarative + Safe)
+
 	internalCtx := context.WithValue(context.Background(), common.SessionInternalKey, true)
-	for scope := range data {
-		for name := range data[scope] {
-			perms := data[scope][name]
-			fmt.Println(scope, name, len(perms))
-			role := &rolev3.Role{
+
+	// Build desired roles map from roles.json
+	desiredRoles := make(map[string]*rolev3.Role)
+
+	for scope, roles := range data {
+		for name, perms := range roles {
+			desiredRoles[name] = &rolev3.Role{
 				Metadata: &commonv3.Metadata{
 					Name:         name,
 					Partner:      *partner,
@@ -296,16 +301,58 @@ func main() {
 					Builtin:         true,
 				},
 			}
+		}
+	}
 
-			_, err := rs.Create(internalCtx, role)
+	// Fetch existing roles from DB
+	existingList, err := rs.List(context.Background(), &rolev3.Role{
+		Metadata: &commonv3.Metadata{
+			Partner:      *partner,
+			Organization: *org,
+		},
+	})
+	if err != nil {
+		log.Fatal("unable to list roles:", err)
+	}
+
+	// Track existing builtin roles
+	existingBuiltin := make(map[string]*rolev3.Role)
+	for _, r := range existingList.Items {
+		if r.Spec.Builtin {
+			existingBuiltin[r.Metadata.Name] = r
+		}
+	}
+
+	// Reconcile desired roles
+	for name, desiredRole := range desiredRoles {
+
+		if existing, exists := existingBuiltin[name]; exists {
+
+			// Role exists → Update (fully replace permissions)
+			desiredRole.Metadata.Id = existing.Metadata.Id
+
+			_, err := rs.Update(internalCtx, desiredRole)
 			if err != nil {
-				if strings.Contains(err.Error(), "already exists") {
-					// role already present, safe to ignore
-					continue
-				}
-				log.Fatalf("unable to create role %s: %v", name, err)
+				log.Fatalf("failed updating builtin role %s: %v", name, err)
 			}
 
+		} else {
+			// Role missing → Create
+			_, err := rs.Create(internalCtx, desiredRole)
+			if err != nil {
+				log.Fatalf("failed creating builtin role %s: %v", name, err)
+			}
+		}
+	}
+
+	//Delete orphan builtin roles (present in DB but removed from JSON)
+	for name, existing := range existingBuiltin {
+		if _, found := desiredRoles[name]; !found {
+
+			_, err := rs.Delete(internalCtx, existing)
+			if err != nil {
+				log.Fatalf("failed deleting orphan builtin role %s: %v", name, err)
+			}
 		}
 	}
 	//default "All Local Users" group should be created


### PR DESCRIPTION

### What does this PR change?

- Ensure builtin roles are reconciled from roles.json
- Delete existing role-permission mappings during initialization
- Recreate mappings based on the updated permissions
- Deduplicate Casbin policy generation
- Make role-permission initialization idempotent

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- 404

## Testing

1. Added `organization.write` permission to `ADMIN_READ_ONLY` in `roles.json`.
2. Re-ran the initialization script.
3. Verified DB update in:

- authsrv_resourcerolepermission

4. Verified Casbin policy generation in:

- casbin_rule

5. Confirmed updated permissions are reflected in the dashboard behavior.

### Checklist

I confirm, that I have...

- [-] Read and followed the contributing guide in `CONTRIBUTING.md`
- [-] Added tests for this PR
- [-] Formatted the code using `go fmt` (if applicable)
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
